### PR TITLE
rewrite: RewriteResultService, EvaluationService, PromptService 구현 및 …

### DIFF
--- a/src/main/java/com/tave/PromptMate/common/NotFoundException.java
+++ b/src/main/java/com/tave/PromptMate/common/NotFoundException.java
@@ -1,0 +1,5 @@
+package com.tave.PromptMate.common;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String msg) { super(msg); }
+}

--- a/src/main/java/com/tave/PromptMate/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/tave/PromptMate/config/GlobalExceptionHandler.java
@@ -1,0 +1,27 @@
+package com.tave.PromptMate.config;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import com.tave.PromptMate.common.NotFoundException;
+
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<?> handleNotFound(NotFoundException e) {
+        return ResponseEntity.status(404).body(e.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> handleValidation(MethodArgumentNotValidException e) {
+        return ResponseEntity.badRequest().body(e.getBindingResult().toString());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> handleEtc(Exception e) {
+        return ResponseEntity.internalServerError().body(e.getMessage());
+    }
+}

--- a/src/main/java/com/tave/PromptMate/repository/CategoryRepository.java
+++ b/src/main/java/com/tave/PromptMate/repository/CategoryRepository.java
@@ -3,5 +3,10 @@ package com.tave.PromptMate.repository;
 import com.tave.PromptMate.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    Optional<Category> findByName(String name);
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/tave/PromptMate/repository/EvaluationRepository.java
+++ b/src/main/java/com/tave/PromptMate/repository/EvaluationRepository.java
@@ -1,7 +1,21 @@
 package com.tave.PromptMate.repository;
 
 import com.tave.PromptMate.domain.Evaluation;
+import com.tave.PromptMate.domain.Prompt;
+import com.tave.PromptMate.domain.RewriteResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface EvaluationRepository extends JpaRepository<Evaluation, Long> {
+
+    // 특정 리라이팅 결과에 대한 모든 평가
+    List<Evaluation> findAllByRewriteResultId(Long rewriteId);
+
+    // 프롬프트+리라이팅 조합으로 단건 조회
+    Optional<Evaluation> findByPromptIdAndRewriteResultId(Long promptId, Long rewriteId);
+
+    List<Evaluation> findAllByPromptOrderByIdDesc(Prompt prompt);
+    List<Evaluation> findAllByRewriteResultOrderByIdDesc(RewriteResult rewriteResult);
 }

--- a/src/main/java/com/tave/PromptMate/repository/PromptRepository.java
+++ b/src/main/java/com/tave/PromptMate/repository/PromptRepository.java
@@ -1,7 +1,24 @@
 package com.tave.PromptMate.repository;
 
+import com.tave.PromptMate.domain.Category;
 import com.tave.PromptMate.domain.Prompt;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface PromptRepository extends JpaRepository<Prompt, Long> {
+
+    // 내 프롬프트 최신순
+    List<Prompt> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+    // 카테고리별 페이지 조회
+    Page<Prompt> findByCategoryId(Long categoryId, Pageable pageable);
+
+    // 권한 체크 (내가 쓴 프롬프트인가)
+    Optional<Prompt> findByIdAndUserId(Long id, Long userId);
+
+    List<Prompt> findAllByCategoryOrderByCreatedAtDesc(Category category);
 }

--- a/src/main/java/com/tave/PromptMate/repository/RewriteResultRepository.java
+++ b/src/main/java/com/tave/PromptMate/repository/RewriteResultRepository.java
@@ -1,7 +1,18 @@
 package com.tave.PromptMate.repository;
 
+import com.tave.PromptMate.domain.Prompt;
 import com.tave.PromptMate.domain.RewriteResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface RewriteResultRepository extends JpaRepository<RewriteResult, Long> {
+
+    // 특정 프롬프트의 리라이팅 결과들(최신순)
+    List<RewriteResult> findAllByPromptIdOrderByCreatedAtDesc(Long promptId);
+
+    // 가장 최근 리라이팅 결과 1건
+    Optional<RewriteResult> findTop1ByPromptIdOrderByCreatedAtDesc(Long promptId);
+    void deleteAllByPrompt(Prompt prompt);
 }

--- a/src/main/java/com/tave/PromptMate/repository/UserRepository.java
+++ b/src/main/java/com/tave/PromptMate/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.tave.PromptMate.repository;
+
+import com.tave.PromptMate.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/tave/PromptMate/service/CategoryService.java
+++ b/src/main/java/com/tave/PromptMate/service/CategoryService.java
@@ -1,0 +1,11 @@
+package com.tave.PromptMate.service;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@AllArgsConstructor
+@Transactional
+public class CategoryService {
+}

--- a/src/main/java/com/tave/PromptMate/service/EvaluationService.java
+++ b/src/main/java/com/tave/PromptMate/service/EvaluationService.java
@@ -1,0 +1,96 @@
+package com.tave.PromptMate.service;
+
+import com.tave.PromptMate.common.NotFoundException;
+import com.tave.PromptMate.domain.Evaluation;
+import com.tave.PromptMate.domain.Prompt;
+import com.tave.PromptMate.domain.RewriteResult;
+import com.tave.PromptMate.dto.evaluation.CreateEvaluationRequest;
+import com.tave.PromptMate.dto.evaluation.EvaluationResponse;
+import com.tave.PromptMate.repository.EvaluationRepository;
+import com.tave.PromptMate.repository.PromptRepository;
+import com.tave.PromptMate.repository.RewriteResultRepository;
+import com.tave.PromptMate.repository.UserRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.tave.PromptMate.dto.evaluation.EvaluationMapper.toResponse;
+
+@Service
+@AllArgsConstructor
+@Transactional
+public class EvaluationService {
+
+    private final UserRepository userRepository;
+    private final PromptRepository promptRepository;
+    private final RewriteResultRepository rewriteResultRepository;
+    private final EvaluationRepository evaluationRepository;
+
+    // 평가 생성하기
+    public EvaluationResponse createEvaluation(CreateEvaluationRequest req){
+        Prompt prompt = promptRepository.findById(req.promptId())
+                .orElseThrow(()-> new NotFoundException("prompt not found: "+req.promptId()));
+        RewriteResult rewrite = rewriteResultRepository.findById(req.rewriteId())
+                .orElseThrow(()->new NotFoundException("rewrite result not found: "+req.rewriteId()));
+
+        Evaluation evaluation = Evaluation.builder()
+                .prompt(prompt)
+                .rewriteResult(rewrite)
+                .clarity(req.clarity())
+                .specificity(req.specificity())
+                .context(req.context())
+                .creativity(req.creativity())
+                .advice(req.advice())
+                .model_name(req.modelName())
+                .build();
+        Evaluation saved = evaluationRepository.save(evaluation);
+        return toResponse(saved);
+    }
+
+    // 프롬프트별 평가 목록
+    @Transactional(readOnly = true)
+    public List<EvaluationResponse> getEvaluationsByPrompt(Long promptId){
+        Prompt prompt = promptRepository.findById(promptId)
+                .orElseThrow(()->new NotFoundException("prompt not found: "+promptId));
+        return evaluationRepository.findAllByPromptOrderByIdDesc(prompt)
+                .stream().map(e -> new EvaluationResponse(
+                        e.getId(),
+                        e.getPrompt().getId(),
+                        e.getRewriteResult().getId(),
+                        e.getClarity(),
+                        e.getSpecificity(),
+                        e.getContext(),
+                        e.getCreativity(),
+                        e.getAdvice(),
+                        e.getModel_name()
+                )).toList();
+    }
+
+    // 리라이트 결과별 평가 목록
+    @Transactional(readOnly = true)
+    public List<EvaluationResponse> getEvaluationsByRewrite(Long rewriteId) {
+        RewriteResult rewrite = rewriteResultRepository.findById(rewriteId)
+                .orElseThrow(() -> new NotFoundException("rewrite result not found: " + rewriteId));
+
+        return evaluationRepository.findAllByRewriteResultOrderByIdDesc(rewrite)
+                .stream()
+                .map(e -> new EvaluationResponse(
+                        e.getId(),
+                        e.getPrompt().getId(),
+                        e.getRewriteResult().getId(),
+                        e.getClarity(),
+                        e.getSpecificity(),
+                        e.getContext(),
+                        e.getCreativity(),
+                        e.getAdvice(),
+                        e.getModel_name()
+                )).toList();
+    }
+
+    // 평가 삭제하기
+    public void deleteEvaluation(Long evaluationId){
+        evaluationRepository.deleteById(evaluationId);
+    }
+}

--- a/src/main/java/com/tave/PromptMate/service/PromptService.java
+++ b/src/main/java/com/tave/PromptMate/service/PromptService.java
@@ -1,0 +1,81 @@
+package com.tave.PromptMate.service;
+
+import com.tave.PromptMate.common.NotFoundException;
+import com.tave.PromptMate.domain.Category;
+import com.tave.PromptMate.domain.Prompt;
+import com.tave.PromptMate.domain.User;
+import com.tave.PromptMate.dto.prompt.CreatePromptRequest;
+import com.tave.PromptMate.dto.prompt.PromptMapper;
+import com.tave.PromptMate.dto.prompt.PromptResponse;
+import com.tave.PromptMate.repository.CategoryRepository;
+import com.tave.PromptMate.repository.PromptRepository;
+import com.tave.PromptMate.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service @RequiredArgsConstructor
+@Transactional
+public class PromptService {
+
+    private final PromptRepository promptRepository;
+    private final UserRepository userRepository;
+    private final CategoryRepository categoryRepository;
+    private final PromptMapper promptMapper;
+
+    // 프롬프트 작성
+    public PromptResponse create(CreatePromptRequest req){
+        User user = userRepository.findById(req.userId())
+                .orElseThrow(() -> new NotFoundException("user not found: " + req.userId()));
+
+        Category category = null;
+        if (req.categoryId() != null){
+            category = categoryRepository.findById(req.categoryId())
+                    .orElseThrow(() -> new NotFoundException("category not found: "+ req.categoryId()));
+        }
+
+        Prompt prompt = PromptMapper.toEntity(req, user, category);
+        Prompt saved = promptRepository.save(prompt);
+        return PromptMapper.toResponse(saved);
+    }
+
+    // 프롬프트 단건 조회
+    @Transactional(readOnly = true)
+    public PromptResponse getById(Long promptId){
+        Prompt prompt = promptRepository.findById(promptId)
+                .orElseThrow(() -> new NotFoundException("prompt not found: " + promptId));
+        return PromptMapper.toResponse(prompt);
+    }
+
+    // 특정 유저의 프롬프트 목록
+    @Transactional(readOnly = true)
+    public List<PromptResponse> getByPrompts(Long userId){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("user not found: " + userId));
+        return promptRepository.findAllByUserIdOrderByCreatedAtDesc(userId)
+                .stream().map(PromptMapper::toResponse).toList();
+    }
+
+    // 카테고리별 목록
+    @Transactional(readOnly = true)
+    public List<PromptResponse> getByCategory(Long categoryId){
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new NotFoundException("category not found: " + categoryId));
+        return promptRepository.findAllByCategoryOrderByCreatedAtDesc(category)
+                .stream().map(PromptMapper::toResponse).toList();
+    }
+
+    // 프롬프트 삭제 - 글 작성자만 삭제하기
+    public void delete(Long promptId, Long requestUserId){
+        Prompt prompt = promptRepository.findById(promptId)
+                .orElseThrow(() -> new NotFoundException("prompt not found: "+promptId));
+        if (!prompt.getUser().getId().equals(requestUserId)){
+            throw new IllegalStateException("no permission to delete this prompt");
+        }
+        promptRepository.delete(prompt);
+    }
+
+
+}

--- a/src/main/java/com/tave/PromptMate/service/RewriteResultService.java
+++ b/src/main/java/com/tave/PromptMate/service/RewriteResultService.java
@@ -1,0 +1,70 @@
+package com.tave.PromptMate.service;
+
+import com.tave.PromptMate.common.NotFoundException;
+import com.tave.PromptMate.domain.Prompt;
+import com.tave.PromptMate.domain.RewriteResult;
+import com.tave.PromptMate.repository.PromptRepository;
+import com.tave.PromptMate.repository.RewriteResultRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RewriteResultService {
+
+    private final RewriteResultRepository rewriteResultRepository;
+    private final PromptRepository promptRepository;
+
+    // 결과 저장하기
+    public Long saveResult(Long promptId,
+                           String modelName,
+                           String content,
+                           Integer inputTokens,
+                           Integer outputTokens,
+                           Long latencyMs){
+
+        // 프롬프트 존재 여부 확인하기
+        Prompt prompt = promptRepository.findById(promptId)
+                .orElseThrow(() -> new NotFoundException("prompt not found: " + promptId));
+
+        // RewriteResult 엔티티 생성 및 저장하기
+        RewriteResult result = RewriteResult.builder()
+                .prompt(prompt)
+                .modelName(modelName)
+                .inputTokens(inputTokens)
+                .outputTokens(outputTokens)
+                .latencyMs(latencyMs)
+                .content(content)
+                .build();
+        RewriteResult saved = rewriteResultRepository.save(result);
+        return saved.getId();
+    }
+
+    // 프롬프트별 리라이트 전체 결과 확인
+    @Transactional(readOnly = true)
+    public List<RewriteResult> getResultsByPrompt(Long promptId){
+        Prompt prompt = promptRepository.findById(promptId)
+                .orElseThrow(() -> new NotFoundException("prompt not found: "+ promptId));
+        return rewriteResultRepository.findAllByPromptIdOrderByCreatedAtDesc(promptId);
+    }
+
+    // 프롬프트별 최신 1건 조회
+    @Transactional(readOnly = true)
+    public RewriteResult getLatestByPrompt(Long promptId){
+        Prompt prompt = promptRepository.findById(promptId)
+                .orElseThrow(() -> new NotFoundException("prompt not found: " + promptId));
+        return rewriteResultRepository.findTop1ByPromptIdOrderByCreatedAtDesc(promptId)
+                .orElseThrow(()-> new NotFoundException("rewrite result not found for prompt: "+ promptId ));
+    }
+
+    // 리라이트 결과 전체 삭제하기
+    public void deleteAllByPrompt(Long promptId){
+        Prompt prompt = promptRepository.findById(promptId)
+                .orElseThrow(() -> new NotFoundException("prompt not found: " + promptId));
+        rewriteResultRepository.deleteAllByPrompt(prompt);
+    }
+}


### PR DESCRIPTION
## 주요 변경사항
- `PromptService`
  - 프롬프트 생성/단건 조회/사용자별·카테고리별 목록 조회
- `RewriteResultService`
  - 프롬프트 존재 검증 후 결과 저장 `saveResult(...)`
  - 프롬프트별 결과 목록/최신 1건 조회
- `EvaluationService`
  - `CreateEvaluationRequest` 기반 평가 생성
  - 프롬프트별/리라이트별 평가 목록 조회
  
---
### 다음 구현 계획
- 카테고리 dto, 도메인, 서비스 구현