### PR TITLE
feat: 카카오 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,12 @@ dependencies {
 	//redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	//json
+	implementation 'org.json:json:20210307'
+
+	//oauth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/tave/PromptMate/PromptMateApplication.java
+++ b/src/main/java/com/tave/PromptMate/PromptMateApplication.java
@@ -11,5 +11,4 @@ public class PromptMateApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(PromptMateApplication.class, args);
 	}
-
 }

--- a/src/main/java/com/tave/PromptMate/auth/client/KakaoApiClient.java
+++ b/src/main/java/com/tave/PromptMate/auth/client/KakaoApiClient.java
@@ -1,0 +1,96 @@
+package com.tave.PromptMate.auth.client;
+
+import com.tave.PromptMate.auth.dto.response.KakaoTokenResponse;
+import com.tave.PromptMate.auth.dto.response.KakaoUserInfo;
+import com.tave.PromptMate.common.KakaoApiException;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@Slf4j
+public class KakaoApiClient {
+
+    @Value("${kakao.oauth.client-id}")
+    private String kakaoClientId;
+
+    @Value("${kakao.oauth.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    private final RestTemplate restTemplate;
+
+
+    public KakaoApiClient(RestTemplateBuilder builder) {
+        this.restTemplate = builder.build();
+    }
+
+    //엑세스 토큰으로 카카오 사용자 정보 조회
+    public KakaoUserInfo getUserInfo(String accessToken) {
+        try {
+            //1. HTTP 헤더 설정
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(accessToken);
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            //2. HTTP 요청 엔티티 생성
+            HttpEntity<Void> request = new HttpEntity<>(headers);
+
+            //3. API 호출
+            ResponseEntity<KakaoUserInfo> response = restTemplate.exchange(
+                    "https://kapi.kakao.com/v2/user/me",
+                    HttpMethod.GET,
+                    request,
+                    KakaoUserInfo.class
+            );
+
+            if (response.getBody() == null) {
+                throw new KakaoApiException("카카오 사용자 정보 응답이 비어있습니다.");
+            }
+            return response.getBody();
+        }catch (RestClientException e){
+            log.error("카카오 사용자 정보 조회 실패", e);
+            throw new KakaoApiException("카카오 사용자 정보를 가져오는데 실패했습니다.");
+        }
+    }
+
+    //프론트에서 받은 인가코드->카카오에 토큰발급 요청->엑세스 토큰 발급
+    public String requestAccessToken(String authorizationCode) {
+        try{
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", kakaoClientId);
+        params.add("redirect_uri", kakaoRedirectUri);
+        params.add("code", authorizationCode);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+            ResponseEntity<KakaoTokenResponse> response = restTemplate.postForEntity(
+                    "https://kauth.kakao.com/oauth/token",
+                    request,
+                    KakaoTokenResponse.class
+            );
+
+            log.info("카카오 토큰 발급 성공: {}", response.getStatusCode());
+
+            if (response.getBody() == null || response.getBody().getAccessToken() == null) {
+                throw new KakaoApiException("카카오 액세스 토큰이 비어있습니다.");
+            }
+
+            return response.getBody().getAccessToken();
+        } catch (RestClientException e) {
+            log.error("카카오 액세스 토큰 요청 실패", e);
+            throw new KakaoApiException("카카오 액세스 토큰 발급에 실패했습니다.", e);
+        }
+    }
+
+}

--- a/src/main/java/com/tave/PromptMate/auth/controller/AuthController.java
+++ b/src/main/java/com/tave/PromptMate/auth/controller/AuthController.java
@@ -1,0 +1,32 @@
+package com.tave.PromptMate.auth.controller;
+
+import com.tave.PromptMate.auth.dto.response.JwtLoginResponse;
+import com.tave.PromptMate.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name="인증", description = "인증 관련 API")
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/api/auth/login/kakao")
+    @Operation(summary = "카카오로그인")
+    public ResponseEntity<JwtLoginResponse> kakaoLogin(@RequestParam String code){
+        JwtLoginResponse jwtLoginResponse= authService.loginOrRegister(code);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.AUTHORIZATION, jwtLoginResponse.getJwtAccessToken())
+                .body(jwtLoginResponse);
+    }
+}

--- a/src/main/java/com/tave/PromptMate/auth/converter/AuthConverter.java
+++ b/src/main/java/com/tave/PromptMate/auth/converter/AuthConverter.java
@@ -1,0 +1,17 @@
+package com.tave.PromptMate.auth.converter;
+
+import com.tave.PromptMate.auth.dto.response.JwtLoginResponse;
+import com.tave.PromptMate.domain.User;
+
+public class AuthConverter {
+
+    public static JwtLoginResponse toJwtLoginResponse(User user, String accessToken, String refreshToken){
+        return JwtLoginResponse.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .nickName(user.getNickname())
+                .jwtAccessToken("Bearer "+accessToken)
+                .jwtRefreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/tave/PromptMate/auth/dto/response/JwtLoginResponse.java
+++ b/src/main/java/com/tave/PromptMate/auth/dto/response/JwtLoginResponse.java
@@ -1,0 +1,15 @@
+package com.tave.PromptMate.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class JwtLoginResponse {
+
+    private Long userId;
+    private String email;
+    private String nickName;
+    private String jwtAccessToken;
+    private String jwtRefreshToken;
+}

--- a/src/main/java/com/tave/PromptMate/auth/dto/response/KakaoTokenResponse.java
+++ b/src/main/java/com/tave/PromptMate/auth/dto/response/KakaoTokenResponse.java
@@ -1,0 +1,23 @@
+package com.tave.PromptMate.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class KakaoTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    @JsonProperty("refresh_token_expires_in")
+    private Integer refreshTokenExpiresIn;
+}

--- a/src/main/java/com/tave/PromptMate/auth/dto/response/KakaoUserInfo.java
+++ b/src/main/java/com/tave/PromptMate/auth/dto/response/KakaoUserInfo.java
@@ -1,0 +1,29 @@
+package com.tave.PromptMate.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class KakaoUserInfo {
+
+    private Long id;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Data
+    public static class KakaoAccount {
+        private String email;
+
+        @JsonProperty("profile")
+        private Profile profile;
+
+        @Data
+        public static class Profile {
+            private String nickname;
+
+            @JsonProperty("profile_image_url")
+            private String profileImageUrl;
+        }
+    }
+}

--- a/src/main/java/com/tave/PromptMate/auth/service/AuthService.java
+++ b/src/main/java/com/tave/PromptMate/auth/service/AuthService.java
@@ -1,0 +1,76 @@
+package com.tave.PromptMate.auth.service;
+
+import com.tave.PromptMate.auth.client.KakaoApiClient;
+import com.tave.PromptMate.auth.converter.AuthConverter;
+import com.tave.PromptMate.auth.dto.response.JwtLoginResponse;
+import com.tave.PromptMate.auth.dto.response.KakaoUserInfo;
+import com.tave.PromptMate.domain.User;
+import com.tave.PromptMate.redis.service.RefreshTokenRedisService;
+import com.tave.PromptMate.repository.UserRepository;
+import com.tave.PromptMate.security.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final KakaoApiClient kakaoApiClient;
+    private final RefreshTokenRedisService refreshTokenRedisService;
+
+    @Value("${jwt.expiration.access}")
+    private Long ACCESS_TOKEN_EXPIRE_TIME;
+
+    @Value("${jwt.expiration.refresh}")
+    private Long REFRESH_TOKEN_EXPIRE_TIME;
+
+    public JwtLoginResponse loginOrRegister(String code){
+
+        //1. 인가 코드로 카카오 access token 요청
+        String kakaoAccessToken= kakaoApiClient.requestAccessToken(code);
+
+        //2. 카카오 access token으로 사용자 정보 조회
+        KakaoUserInfo kakaoUserInfo=kakaoApiClient.getUserInfo(kakaoAccessToken);
+        String email=kakaoUserInfo.getKakaoAccount().getEmail();
+        String profileImage=kakaoUserInfo.getKakaoAccount().getProfile().getProfileImageUrl();
+
+        //3. 회원 조회 또는 생성
+        User user=userRepository.findByEmail(email)
+                .orElseGet(()->{
+                    String nicknameToUse=generateRandomNickname();
+                    return userRepository.save(User.builder()
+                                    .email(email)
+                                    .nickname(nicknameToUse)
+                                    .imageUrl(profileImage)
+                            .build());
+                });
+
+        //4. Access & RefreshToken 생성
+        String userIdStr=user.getId().toString();
+        Authentication authentication=jwtUtil.getAuthenticationFromUserId(userIdStr);
+        String accessToken= jwtUtil.generateAccessToken(authentication,userIdStr);
+        String refreshToken= jwtUtil.generateRefreshToken(authentication,userIdStr);
+
+        //5. Refresh Token을 Redis에 저장
+        refreshTokenRedisService.saveRefreshToken(user.getId(),refreshToken,REFRESH_TOKEN_EXPIRE_TIME);
+
+        //6. jwtLoginResponse 반환
+        return AuthConverter.toJwtLoginResponse(user,accessToken,refreshToken);
+    }
+
+    
+    //닉네임 랜덤 생성
+    private String generateRandomNickname() {
+        return "user_" + UUID.randomUUID().toString().substring(0, 8);
+    }
+
+
+}

--- a/src/main/java/com/tave/PromptMate/common/KakaoApiException.java
+++ b/src/main/java/com/tave/PromptMate/common/KakaoApiException.java
@@ -1,0 +1,11 @@
+package com.tave.PromptMate.common;
+
+public class KakaoApiException extends RuntimeException {
+    public KakaoApiException(String message) {
+        super(message);
+    }
+
+    public KakaoApiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/tave/PromptMate/domain/Role.java
+++ b/src/main/java/com/tave/PromptMate/domain/Role.java
@@ -1,0 +1,12 @@
+package com.tave.PromptMate.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum Role {
+    USER("ROLE_USER"), ADMIN("ROLE_ADMIN");
+
+    private final String value;
+}

--- a/src/main/java/com/tave/PromptMate/security/jwt/JwtUtil.java
+++ b/src/main/java/com/tave/PromptMate/security/jwt/JwtUtil.java
@@ -9,6 +9,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
@@ -131,6 +132,13 @@ public class JwtUtil {
             log.error("Failed to extract subject from token: {}", e.getMessage());
             return null; // or throw new TokenException(SecurityErrorCode.INVALID_TOKEN);
         }
+    }
+
+    //인가된 사용자 꺼내기
+    public Authentication getAuthenticationFromUserId(String userId) {
+        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+        User principal = new User(userId, "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, null, authorities);
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,10 @@ jwt:
     access: ${ACCESS_EXPIRATION:1800000}
     refresh: ${REFRESH_EXPIRATION:2592000000}
   secret: ${JWT_SECRET:O0qN1qz7fFvYWq6m1HZjlpajM3U4Yjrcm1DQxq8PjVrNZo+M8c2AtbT/1E84exuGdR8zNQG4Yp2xj0FSLxK+Dw==}
+
+kakao:
+  oauth:
+    client_id: ${KAKAO_CLIENT_ID}
+    redirect_uri: ${KAKAO_REDIRECT_URI}
+    token-uri: https://kauth.kakao.com/oauth/token
+    user-info-uri: https://kapi.kakao.com/v2/user/me


### PR DESCRIPTION


close #11 

## 📝 작업 내용

- 카카오 로그인 구현
- 닉네임 랜던 생성
- 카카오 access token-> 사용자 정보 조회
- 사용자 정보로우리 시스템 로그인/회원가입
- 우리 서버가 자체 JWT(access+refresh) 발급 
<img width="1211" height="620" alt="image" src="https://github.com/user-attachments/assets/4c479e13-53bc-4909-ae6c-cc89d361f619" />

<img width="1189" height="375" alt="image" src="https://github.com/user-attachments/assets/aee0c44a-eb29-4b65-a4a0-0b20ad17b563" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

