### PR TITLE
리라이팅 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,3 @@ src/main/resources/application-*.yaml
 !src/main/resources/application-example.yml
 application-jwt.yml
 application-oauth.yml
-

--- a/src/main/java/com/tave/PromptMate/controller/RewriteController.java
+++ b/src/main/java/com/tave/PromptMate/controller/RewriteController.java
@@ -1,4 +1,53 @@
 package com.tave.PromptMate.controller;
 
+import com.tave.PromptMate.dto.rewrite.CreateRewriteRequest;
+import com.tave.PromptMate.dto.rewrite.RewriteResponse;
+import com.tave.PromptMate.service.RewriteResultService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
 public class RewriteController {
+
+    private final RewriteResultService rewriteResultService;
+
+    // 리라이티 결과 생성(저장)하기
+    @PostMapping("rewrite-results")
+    public ResponseEntity<RewriteResponse> create(@RequestBody @Valid CreateRewriteRequest req){
+        RewriteResponse res = rewriteResultService.create(req);
+        return ResponseEntity.created(URI.create("/api/rewrite-results/" + res.id())).body(res);
+    }
+
+    // 프롬프트별 리라이팅 결과 전체 목록 조회
+    @GetMapping("/prompts/{promptId}/rewrites")
+    public ResponseEntity<List<RewriteResponse>> getByPrompt(@PathVariable Long promptId){
+        return ResponseEntity.ok(rewriteResultService.getListByPrompt(promptId));
+    }
+
+    // 프롬프트별 최신 1건 조회
+    @GetMapping("/prompts/{promptId}/rewrites/latest")
+    public ResponseEntity<RewriteResponse> getLatest(@PathVariable Long promptId){
+        RewriteResponse res = rewriteResultService.getLatestByPrompt(promptId);
+        return ResponseEntity.ok(res);
+    }
+
+    // 리라이팅 결과 단건 조회
+    @GetMapping("/rewrite-results/{id}")
+    public ResponseEntity<RewriteResponse> getOne(@PathVariable Long id){
+        return ResponseEntity.ok(rewriteResultService.getOne(id));
+    }
+
+    // 리라이팅 삭제하기
+    @DeleteMapping("/rewrite-results/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id){
+        rewriteResultService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/tave/PromptMate/dto/rewrite/CreateRewriteRequest.java
+++ b/src/main/java/com/tave/PromptMate/dto/rewrite/CreateRewriteRequest.java
@@ -3,8 +3,6 @@ package com.tave.PromptMate.dto.rewrite;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-import java.time.LocalDateTime;
-
 public record CreateRewriteRequest(
         @NotNull Long id,
         @NotNull Long promptId,
@@ -12,7 +10,5 @@ public record CreateRewriteRequest(
         @NotBlank String content,
         @NotNull Integer inputTokens,
         @NotNull Integer outputTokens,
-        @NotNull Long latencyMs,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        @NotNull Long latencyMs
 ) {}

--- a/src/main/java/com/tave/PromptMate/dto/rewrite/RewriteMapper.java
+++ b/src/main/java/com/tave/PromptMate/dto/rewrite/RewriteMapper.java
@@ -25,9 +25,7 @@ public final class RewriteMapper {
                 r.getContent(),
                 r.getInputTokens(),
                 r.getOutputTokens(),
-                r.getLatencyMs(),
-                r.getCreatedAt(),
-                r.getUpdatedAt()
+                r.getLatencyMs()
         );
     }
 }

--- a/src/main/java/com/tave/PromptMate/dto/rewrite/RewriteResponse.java
+++ b/src/main/java/com/tave/PromptMate/dto/rewrite/RewriteResponse.java
@@ -1,7 +1,5 @@
 package com.tave.PromptMate.dto.rewrite;
 
-import java.time.LocalDateTime;
-
 public record RewriteResponse(
         Long id,
         Long promptId,
@@ -9,8 +7,6 @@ public record RewriteResponse(
         String content,
         Integer inputTokens,
         Integer outputTokens,
-        Long latencyMs,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        Long latencyMs
 ) {
 }

--- a/src/main/java/com/tave/PromptMate/repository/RewriteResultRepository.java
+++ b/src/main/java/com/tave/PromptMate/repository/RewriteResultRepository.java
@@ -1,6 +1,5 @@
 package com.tave.PromptMate.repository;
 
-import com.tave.PromptMate.domain.Prompt;
 import com.tave.PromptMate.domain.RewriteResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,10 +8,9 @@ import java.util.Optional;
 
 public interface RewriteResultRepository extends JpaRepository<RewriteResult, Long> {
 
-    // 특정 프롬프트의 리라이팅 결과들(최신순)
-    List<RewriteResult> findAllByPromptIdOrderByCreatedAtDesc(Long promptId);
+    // 최신 리라이팅 1건
+    Optional<RewriteResult> findTopByPromptIdOrderByCreatedAtDesc(Long promptId);
 
-    // 가장 최근 리라이팅 결과 1건
-    Optional<RewriteResult> findTop1ByPromptIdOrderByCreatedAtDesc(Long promptId);
-    void deleteAllByPrompt(Prompt prompt);
+    // 프롬프트별 전체 리라이팅 (최신순)
+    List<RewriteResult> findByPromptIdOrderByCreatedAtDesc(Long promptId);
 }


### PR DESCRIPTION
## 작업 개요
리라이팅 결과를 생성·저장하고, 프롬프트 기준 조회, 최신 기록 조회, 단건 조회 및 삭제까지 포함한 전체 RewriteResult CRUD + Query 기능을 제공합니다.

## 작업 내용
1) DTO 2종 + Mapper 구현
- CreateRewriteRequest
- RewriteResponse
- RewriteMapper (Entity ↔ DTO 변환)

2) Repository 구현
- findTopByPromptIdOrderByCreatedAtDesc() — 최신 리라이팅
- findByPromptIdOrderByCreatedAtDesc() — 프롬프트별 전체 목록

3) Service 레이어 전체 구현
- create() — 리라이팅 생성 + 저장
- getLatest(promptId) — 프롬프트 기준 최신 결과 조회
- getByPrompt(promptId) — 프롬프트 기준 전체 목록 조회
- getOne(id) — 단건 조회
- delete(id) — 삭제

6) Controller 레이어 구현
- POST /api/rewrite-results — 리라이팅 생성
- GET /api/prompts/{promptId}/rewrites/latest — 최신 조회
- GET /api/prompts/{promptId}/rewrites — 전체 조회
- GET /api/rewrite-results/{id} — 단건 조회
- DELETE /api/rewrite-results/{id} — 삭제
-> PromptController와 동일한 ResponseEntity 스타일로 통일.