### PR TITLE
[FEAT] 커뮤니티 게시글 댓글/답글 구현

### DIFF
--- a/src/main/java/com/tave/PromptMate/controller/CommentController.java
+++ b/src/main/java/com/tave/PromptMate/controller/CommentController.java
@@ -1,0 +1,72 @@
+package com.tave.PromptMate.controller;
+
+import com.tave.PromptMate.auth.dto.request.CustomUserDetails;
+import com.tave.PromptMate.domain.Comment;
+import com.tave.PromptMate.dto.comment.CommentResponse;
+import com.tave.PromptMate.dto.comment.CreateCommentRequest;
+import com.tave.PromptMate.dto.comment.CreateReplyRequest;
+import com.tave.PromptMate.dto.comment.UpdateCommentRequest;
+import com.tave.PromptMate.service.CommentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    // 댓글 등록
+    @PostMapping
+    public ResponseEntity<CommentResponse> createComment(
+            @Valid@RequestBody CreateCommentRequest req,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+            ){
+        Long userId=userDetails.getUserId();
+        return  ResponseEntity.ok(commentService.createdComment(req,userId));
+    }
+
+    // 답글 등록
+    @PostMapping("/replies")
+    public ResponseEntity<CommentResponse> createReply(
+            @Valid @RequestBody CreateReplyRequest req,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ){
+        Long userId=userDetails.getUserId();
+        return ResponseEntity.ok(commentService.createReply(req, userId));
+    }
+
+    // 게시글 기준 댓글/답글 조회
+    @GetMapping("/community/{communityId}")
+    public ResponseEntity<List<CommentResponse>> getCommentByCommunity(@PathVariable Long communityId){
+        return ResponseEntity.ok(commentService.getCommentsByCommunity(communityId));
+    }
+
+    // 댓글 수정
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<CommentResponse> updateComment(
+            @PathVariable Long commentId,
+            @Valid @RequestBody UpdateCommentRequest req,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+            ){
+        Long userId=userDetails.getUserId();
+        return ResponseEntity.ok(commentService.updateComment(commentId,req,userId));
+    }
+
+    // 댓글 삭제
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ){
+        Long userId=userDetails.getUserId();
+        commentService.deleteComment(commentId,userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/tave/PromptMate/domain/Comment.java
+++ b/src/main/java/com/tave/PromptMate/domain/Comment.java
@@ -1,0 +1,81 @@
+package com.tave.PromptMate.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "comment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseTimeEntity{
+
+    public enum Status{
+        NORMAL,
+        REMOVED
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 어떤 게시글에 달린 댓글인지
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="community_id", nullable = false)
+    private Community community;
+
+    // 누가 댓글 작성했는지
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 답글이면 부모 댓글이 존재, 일반 댓글이면 null
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    // 부모 댓글 기준 답글 목록
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+    private List<Comment> replies= new ArrayList<>();
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Status status;
+
+    public static Comment create(Community community, User user, Comment parent, String content){
+        Comment c= new Comment();
+        c.community=community;
+        c.user=user;
+        c.parent=parent;
+        c.content=content;
+        c.status=Status.NORMAL;
+        return c;
+    }
+
+    public void updateContent(String content){
+        this.content=content;
+    }
+
+    public void remove(){
+        this.status=Status.REMOVED;
+        this.content="삭제된 댓글입니다.";
+    }
+
+    public boolean isRemoved(){
+        return this.status==Status.REMOVED;
+    }
+
+    public void setParent(Comment parent){
+        this.parent=parent;
+        if(parent!=null){
+            parent.replies.add(this);
+        }
+    }
+}

--- a/src/main/java/com/tave/PromptMate/dto/comment/CommentMapper.java
+++ b/src/main/java/com/tave/PromptMate/dto/comment/CommentMapper.java
@@ -1,0 +1,28 @@
+package com.tave.PromptMate.dto.comment;
+
+import com.tave.PromptMate.domain.Comment;
+
+import java.util.Comparator;
+import java.util.List;
+
+public class CommentMapper {
+
+    public static CommentResponse toResponse(Comment comment){
+        List<CommentResponse> replies=comment.getReplies().stream()
+                .sorted(Comparator.comparing(Comment::getCreatedAt))
+                .map(CommentMapper::toResponse)
+                .toList();
+
+        return new CommentResponse(
+                comment.getId(),
+                comment.getCommunity().getId(),
+                comment.getUser().getId(),
+                comment.getUser().getNickname(),
+                comment.getParent() !=null ? comment.getParent().getId() : null,
+                comment.getContent(),
+                comment.getStatus().name(),
+                comment.getCreatedAt(),
+                replies
+        );
+    }
+}

--- a/src/main/java/com/tave/PromptMate/dto/comment/CommentResponse.java
+++ b/src/main/java/com/tave/PromptMate/dto/comment/CommentResponse.java
@@ -1,0 +1,16 @@
+package com.tave.PromptMate.dto.comment;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CommentResponse(
+        Long id,
+        Long communityId,
+        Long userId,
+        String nickname,
+        Long parentId,
+        String content,
+        String status,
+        LocalDateTime createdAt,
+        List<CommentResponse> replies
+) {}

--- a/src/main/java/com/tave/PromptMate/dto/comment/CreateCommentRequest.java
+++ b/src/main/java/com/tave/PromptMate/dto/comment/CreateCommentRequest.java
@@ -1,0 +1,9 @@
+package com.tave.PromptMate.dto.comment;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateCommentRequest (
+    @NotNull Long communityId,
+    @NotBlank String content
+) {}

--- a/src/main/java/com/tave/PromptMate/dto/comment/CreateReplyRequest.java
+++ b/src/main/java/com/tave/PromptMate/dto/comment/CreateReplyRequest.java
@@ -1,0 +1,9 @@
+package com.tave.PromptMate.dto.comment;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateReplyRequest(
+        @NotNull long parentId,
+        @NotBlank String content
+) {}

--- a/src/main/java/com/tave/PromptMate/dto/comment/UpdateCommentRequest.java
+++ b/src/main/java/com/tave/PromptMate/dto/comment/UpdateCommentRequest.java
@@ -1,0 +1,7 @@
+package com.tave.PromptMate.dto.comment;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateCommentRequest(
+        @NotBlank String content
+) {}

--- a/src/main/java/com/tave/PromptMate/repository/CommentRepository.java
+++ b/src/main/java/com/tave/PromptMate/repository/CommentRepository.java
@@ -1,0 +1,14 @@
+package com.tave.PromptMate.repository;
+
+import com.tave.PromptMate.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByCommunityIdAndParentIsNullOrderByCreatedAtAsc(Long communityId);
+
+    List<Comment> findByParentIdOrderByCreatedAtAsc(Long parentId);
+
+    long countByCommunityId(long communityId);
+}

--- a/src/main/java/com/tave/PromptMate/service/CommentService.java
+++ b/src/main/java/com/tave/PromptMate/service/CommentService.java
@@ -1,0 +1,104 @@
+package com.tave.PromptMate.service;
+
+import com.tave.PromptMate.common.NotFoundException;
+import com.tave.PromptMate.domain.Comment;
+import com.tave.PromptMate.domain.Community;
+import com.tave.PromptMate.domain.User;
+import com.tave.PromptMate.dto.comment.*;
+import com.tave.PromptMate.repository.CommentRepository;
+import com.tave.PromptMate.repository.CommunityRepository;
+import com.tave.PromptMate.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final CommunityRepository communityRepository;
+    private final UserRepository userRepository;
+
+    // 댓글 등록
+    public CommentResponse createdComment(CreateCommentRequest req, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자입니다. id=" + userId));
+
+        Community community = communityRepository.findById(req.communityId())
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 게시글입니다. id=" + req.communityId()));
+
+        Comment comment = Comment.create(community, user, null, req.content());
+        Comment saved = commentRepository.save(comment);
+
+        return CommentMapper.toResponse(saved);
+    }
+
+    // 답글 등록 (부모 댓글 기준)
+    public CommentResponse createReply(CreateReplyRequest req, Long userId){
+        User user=userRepository.findById(userId)
+                .orElseThrow(()->new NotFoundException("존재하지 않는 사용자입니다. id="+userId));
+
+        Comment parent=commentRepository.findById(req.parentId())
+                .orElseThrow(()->new NotFoundException("존재하지 않는 부모 댓글입니다. id="+req.parentId()));
+
+        if(parent.isRemoved()){
+            throw new IllegalStateException("삭제된 댓글에는 답글을 달 수 없습니다.");
+        }
+
+        Community community=parent.getCommunity();
+
+        //답글 생성
+        Comment reply=Comment.create(community, user, parent, req.content());
+
+        Comment saved=commentRepository.save(reply);
+        return CommentMapper.toResponse(saved);
+    }
+
+    // 게시글 기준 댓글/답글 조회
+    @Transactional(readOnly = true)
+    public List<CommentResponse> getCommentsByCommunity(Long communityId){
+
+        communityRepository.findById(communityId)
+                .orElseThrow(()->new NotFoundException("존재하지 않는 게시글입니다. id="+communityId));
+
+        List<Comment> roots=commentRepository.findByCommunityIdAndParentIsNullOrderByCreatedAtAsc(communityId);
+
+        return roots.stream()
+                .map(CommentMapper::toResponse)
+                .toList();
+    }
+
+    // 댓글 수정 (작성자만 가능)
+    public CommentResponse updateComment(Long commentId, UpdateCommentRequest req, Long userId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 댓글입니다. id=" + commentId));
+
+        if (comment.isRemoved()) {
+            throw new IllegalStateException("삭제된 댓글은 수정할 수 없습니다.");
+        }
+
+        if (!comment.getUser().getId().equals(userId)) {
+            throw new IllegalStateException("수정 권한이 없습니다.");
+        }
+
+        comment.updateContent(req.content());
+        return CommentMapper.toResponse(comment);
+    }
+        // 댓글 삭제 (작성자만 가능)
+        public void deleteComment(Long commentId, Long userId){
+            Comment comment=commentRepository.findById(commentId)
+                    .orElseThrow(()->new NotFoundException("존재하지 않는 댓글입니다. id="+commentId));
+
+            if(!comment.getUser().getId().equals(userId)){
+                throw new IllegalStateException("삭제 권한이 없습니다.");
+            }
+
+            comment.remove();
+        }
+
+
+}


### PR DESCRIPTION
close #48


## 📝 작업 내용

댓글 등록 API 구현
답글 등록 API 구현 (부모 댓글 기준)
게시글 기준 댓글/답글 조회 API 구현
댓글 → 답글 구조로 중첩된 형태로 반환
댓글 수정(PATCH) 기능 구현
댓글 삭제(soft delete) 처리
작성자 본인만 수정/삭제 가능하도록 권한 체크
커뮤니티 ID 기준으로 댓글 조회 가능
<img width="642" height="325" alt="스크린샷 2025-12-28 오후 9 09 15" src="https://github.com/user-attachments/assets/c84d1f14-7791-467a-96ae-f41a4b686a9c" />
<img width="574" height="287" alt="스크린샷 2025-12-28 오후 9 12 53" src="https://github.com/user-attachments/assets/ea4f0252-22db-4846-9ad9-6a60e3fa1f1c" />
<img width="626" height="457" alt="스크린샷 2025-12-28 오후 9 13 09" src="https://github.com/user-attachments/assets/20ac23ae-17c6-4746-8c2b-64d6f3638a11" />

<img width="613" height="456" alt="스크린샷 2025-12-28 오후 9 14 11" src="https://github.com/user-attachments/assets/856ab67c-f631-482c-918b-56ba9287fc1f" />
<img width="604" height="495" alt="스크린샷 2025-12-28 오후 9 14 41" src="https://github.com/user-attachments/assets/d61e65c8-0f7b-4199-aff2-72941e1cd995" />


