### PR TITLE
feat: 커뮤니티 게시글 좋아요 기능 추가

### DIFF
--- a/src/main/java/com/tave/PromptMate/controller/CommunityLikeController.java
+++ b/src/main/java/com/tave/PromptMate/controller/CommunityLikeController.java
@@ -1,0 +1,34 @@
+package com.tave.PromptMate.controller;
+
+import com.tave.PromptMate.auth.dto.request.CustomUserDetails;
+import com.tave.PromptMate.service.CommunityLikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/communities")
+public class CommunityLikeController {
+
+    private final CommunityLikeService communityLikeService;
+
+    @PostMapping("/{communityId}/likes")
+    public ResponseEntity<Void> like(
+            @PathVariable Long communityId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+            ){
+        communityLikeService.like(communityId, userDetails.getUserId());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{communityId}/likes")
+    public ResponseEntity<Void> unlike(
+            @PathVariable Long communityId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ){
+        communityLikeService.unlike(communityId, userDetails.getUserId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/tave/PromptMate/domain/CommunityLike.java
+++ b/src/main/java/com/tave/PromptMate/domain/CommunityLike.java
@@ -1,0 +1,50 @@
+package com.tave.PromptMate.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "community_like",
+        uniqueConstraints = {
+                @UniqueConstraint(name="uk_community_like_user_community", columnNames = {"user_id", "community_id"})
+        },
+        indexes = {
+                @Index(name = "idx_community_like_user", columnList = "user_id"),
+                @Index(name = "idx_community_like_community", columnList = "community_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommunityLike extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 좋아요 누른 사용자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 좋아요 대상 게시글
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "community_id", nullable = false)
+    private Community community;
+
+    @Builder
+    private CommunityLike(User user, Community community){
+        this.user=user;
+        this.community=community;
+    }
+
+    public static CommunityLike of(User user, Community community){
+        return CommunityLike.builder()
+                .user(user)
+                .community(community)
+                .build();
+    }
+}

--- a/src/main/java/com/tave/PromptMate/repository/CommunityLikeRepository.java
+++ b/src/main/java/com/tave/PromptMate/repository/CommunityLikeRepository.java
@@ -1,0 +1,13 @@
+package com.tave.PromptMate.repository;
+
+import com.tave.PromptMate.domain.CommunityLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommunityLikeRepository extends JpaRepository<CommunityLike, Long> {
+
+    boolean existsByUserIdAndCommunityId(Long userId, Long communityId);
+
+    long countByCommunityId(Long communityId);
+
+    void deleteByUserIdAndCommunityId(Long userId, Long communityId);
+}

--- a/src/main/java/com/tave/PromptMate/service/CommunityLikeService.java
+++ b/src/main/java/com/tave/PromptMate/service/CommunityLikeService.java
@@ -1,0 +1,58 @@
+package com.tave.PromptMate.service;
+
+import com.tave.PromptMate.domain.Community;
+import com.tave.PromptMate.domain.CommunityLike;
+import com.tave.PromptMate.domain.User;
+import com.tave.PromptMate.repository.CommunityLikeRepository;
+import com.tave.PromptMate.repository.CommunityRepository;
+import com.tave.PromptMate.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommunityLikeService {
+
+    private final CommunityRepository communityRepository;
+    private final UserRepository userRepository;
+    private final CommunityLikeRepository communityLikeRepository;
+
+    @Transactional
+    public void like(Long communityId, Long userId){
+
+        // 게시글 존재 확인
+        Community community = communityRepository.findById(communityId)
+                .orElseThrow(()->new IllegalStateException("게시글이 존재하지 않습니다."));
+
+        // 사용자 존재 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new IllegalStateException("사용자가 존재하지 않습니다."));
+
+        // 이미 좋아요 눌렀으면 그냥 종료
+        if (communityLikeRepository.existsByUserIdAndCommunityId(userId, communityId)){
+            return;
+        }
+        communityLikeRepository.save(CommunityLike.of(user, community));
+    }
+
+    @Transactional
+    public void unlike(Long communityId, Long userId) {
+        if (!communityLikeRepository.existsByUserIdAndCommunityId(userId, communityId)) {
+            return;
+        }
+        communityLikeRepository.deleteByUserIdAndCommunityId(userId, communityId);
+    }
+
+    @Transactional(readOnly = true)
+    public long getLikeCount(Long communityId){
+        return communityLikeRepository.countByCommunityId(communityId);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isLiked(Long communityId, Long userId){
+        if(userId==null) return false;
+        return communityLikeRepository.existsByUserIdAndCommunityId(userId, communityId);
+    }
+}
+


### PR DESCRIPTION
close #52 

## 📝 작업 내용

> 커뮤니티 게시글 좋아요 / 좋아요 취소 기능 구현

> 사용자별 좋아요 여부 판별 로직 추가

> 게시글 조회 시 likeCount, isLiked 함께 반환

> 게시글 작성 시 기본 좋아요 수 0, isLiked=false로 초기화

