### PR TITLE
feat: rewrite 모델 연동 프리뷰 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ dependencies {
 	//oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+	implementation "org.springframework.boot:spring-boot-starter-web"
+	implementation "org.apache.httpcomponents.client5:httpclient5"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/tave/PromptMate/PromptMateApplication.java
+++ b/src/main/java/com/tave/PromptMate/PromptMateApplication.java
@@ -1,11 +1,14 @@
 package com.tave.PromptMate;
 
+import com.tave.PromptMate.config.RewriteAiProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableConfigurationProperties(RewriteAiProperties.class)
 public class PromptMateApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/tave/PromptMate/common/HttpRewriteRunner.java
+++ b/src/main/java/com/tave/PromptMate/common/HttpRewriteRunner.java
@@ -1,0 +1,69 @@
+package com.tave.PromptMate.common;
+
+import com.tave.PromptMate.config.RewriteAiProperties;
+import com.tave.PromptMate.dto.rewrite.AiRewriteResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Primary
+@Component
+@RequiredArgsConstructor
+public class HttpRewriteRunner implements RewriteRunner{
+    private final RestTemplate restTemplate;
+    private final RewriteAiProperties props;
+
+    @Override
+    public AiRewriteResult run(String beforeText) {
+        long start = System.currentTimeMillis();
+
+        String url =
+                props.getBaseUrl().replaceAll("/$", "")
+                        + "/"
+                        + props.getPath().replaceAll("^/", "");
+
+
+        System.out.println("AI rewrite url = " + url);
+
+        Map<String, Object> body = Map.of("prompt", beforeText == null ? "" : beforeText);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+
+        try{
+            System.out.println("AI rewrite url = " + url);
+            System.out.println("AI rewrite timeoutMs = " + props.getTimeoutMs());
+
+            ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.POST, request, Map.class);
+
+            long latency = System.currentTimeMillis() - start;
+
+            if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+                throw new RuntimeException("AI rewrite server invalid response: " + response.getStatusCode());
+            }
+
+            Object rewriteFinal = response.getBody().get("rewrite_final");
+            if (rewriteFinal == null) {
+                throw new RuntimeException("AI rewrite response missing 'rewrite_final'");
+            }
+            return new AiRewriteResult(
+                    rewriteFinal.toString(),
+                    0,
+                    0,
+                    latency,
+                    "RewriteModel",
+                    "v1"
+            );
+        } catch (RestClientException e){
+            e.printStackTrace();
+            throw new RuntimeException("AI rewrite server call failed", e);
+        }
+    }
+}

--- a/src/main/java/com/tave/PromptMate/config/RestTemplateConfig.java
+++ b/src/main/java/com/tave/PromptMate/config/RestTemplateConfig.java
@@ -1,0 +1,37 @@
+package com.tave.PromptMate.config;
+
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RewriteAiProperties props) {
+
+        int connectTimeoutMs = 5_000;
+        int readTimeoutMs = props.getTimeoutMs(); // 예: 180000으로 올리기!
+
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(connectTimeoutMs, TimeUnit.MILLISECONDS)
+                .setResponseTimeout(readTimeoutMs, TimeUnit.MILLISECONDS)
+                .build();
+
+        CloseableHttpClient httpClient = HttpClients.custom()
+                .setDefaultRequestConfig(requestConfig)
+                .build();
+
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(httpClient);
+        factory.setConnectTimeout(connectTimeoutMs);
+        factory.setReadTimeout(readTimeoutMs);
+
+        return new RestTemplate(factory);
+    }
+}

--- a/src/main/java/com/tave/PromptMate/config/RewriteAiProperties.java
+++ b/src/main/java/com/tave/PromptMate/config/RewriteAiProperties.java
@@ -1,0 +1,13 @@
+package com.tave.PromptMate.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter @Setter
+@ConfigurationProperties(prefix = "ai.rewrite")
+public class RewriteAiProperties {
+    private String baseUrl;
+    private String path;
+    private int timeoutMs;
+}

--- a/src/main/java/com/tave/PromptMate/controller/RewriteController.java
+++ b/src/main/java/com/tave/PromptMate/controller/RewriteController.java
@@ -1,7 +1,7 @@
 package com.tave.PromptMate.controller;
 
-import com.tave.PromptMate.dto.rewrite.CreateRewriteRequest;
-import com.tave.PromptMate.dto.rewrite.RewriteResponse;
+import com.tave.PromptMate.common.RewriteRunner;
+import com.tave.PromptMate.dto.rewrite.*;
 import com.tave.PromptMate.service.RewriteResultService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +17,24 @@ import java.util.List;
 public class RewriteController {
 
     private final RewriteResultService rewriteResultService;
+    private final RewriteRunner rewriteRunner;
+
+
+    @PostMapping("/rewrite")
+    public ResponseEntity<RewritePreviewResponse> preview(@Valid @RequestBody RewritePreviewRequest req) {
+        AiRewriteResult result = rewriteRunner.run(req.prompt());
+        System.out.println("RewriteRunner bean = " + rewriteRunner.getClass().getName());
+
+
+        return ResponseEntity.ok(new RewritePreviewResponse(
+                result.rewrittenContent(),
+                result.latencyMs(),
+                result.modelName(),
+                result.version()
+        ));
+
+    }
+
 
     // 리라이티 결과 생성(저장)하기
     @PostMapping("rewrite-results")

--- a/src/main/java/com/tave/PromptMate/dto/rewrite/RewritePreviewRequest.java
+++ b/src/main/java/com/tave/PromptMate/dto/rewrite/RewritePreviewRequest.java
@@ -1,0 +1,8 @@
+package com.tave.PromptMate.dto.rewrite;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RewritePreviewRequest(
+        @NotBlank(message = "prompt is required")
+        String prompt
+) {}

--- a/src/main/java/com/tave/PromptMate/dto/rewrite/RewritePreviewResponse.java
+++ b/src/main/java/com/tave/PromptMate/dto/rewrite/RewritePreviewResponse.java
@@ -1,0 +1,8 @@
+package com.tave.PromptMate.dto.rewrite;
+
+public record RewritePreviewResponse(
+        String rewrittenPrompt,
+        Long latencyMs,
+        String modelName,
+        String version
+) {}


### PR DESCRIPTION
# 작업 내용

- RewriteModel(8000) 호출하여 리라이팅 결과를 즉시 반환하는 프리뷰 API 구현
- local 환경에서는 DummyRewriteRunner 유지, 배포/서버 환경에서는 HttpRewriteRunner로 AI 서버 호출하도록 분기
- AI 서버 장애/타임아웃 시 예외 처리 및 오류 응답 반환

# 구현 범위

- POST /api/rewrite 프리뷰 엔드포인트 구현

- RewriteRunner 인터페이스 기반으로 실행체 분리(Dummy/HTTP)

- AI 서버 요청 스펙: { "prompt": "..." } / 응답 파싱 및 결과 매핑

# 테스트 방법

- POST /api/rewrite 호출

- Request Body:

{"prompt":"생성형 AI 프롬프트 관련 서비스 기획을 정리하려는데..."}


- 기대 결과: 200 OK + rewrittenPrompt 반환

# 참고

- AI 서버 URL: http://43.202.3.51:8000/rewrite
<img width="755" height="721" alt="image" src="https://github.com/user-attachments/assets/290ae1b9-bc3f-4a3b-888a-c0ce0459780f" />
