### PR TITLE
feat: 커뮤니티 좋아요 토글 API로 변경

### DIFF
--- a/src/main/java/com/tave/PromptMate/controller/CommunityLikeController.java
+++ b/src/main/java/com/tave/PromptMate/controller/CommunityLikeController.java
@@ -1,6 +1,7 @@
 package com.tave.PromptMate.controller;
 
 import com.tave.PromptMate.auth.dto.request.CustomUserDetails;
+import com.tave.PromptMate.dto.community.CommunityLikeToggleResponse;
 import com.tave.PromptMate.service.CommunityLikeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,20 +16,13 @@ public class CommunityLikeController {
     private final CommunityLikeService communityLikeService;
 
     @PostMapping("/{communityId}/likes")
-    public ResponseEntity<Void> like(
+    public ResponseEntity<CommunityLikeToggleResponse> toggleLike(
             @PathVariable Long communityId,
             @AuthenticationPrincipal CustomUserDetails userDetails
-            ){
-        communityLikeService.like(communityId, userDetails.getUserId());
-        return ResponseEntity.ok().build();
-    }
+    ) {
+        CommunityLikeToggleResponse response =
+                communityLikeService.toggleLike(communityId, userDetails.getUserId());
 
-    @DeleteMapping("/{communityId}/likes")
-    public ResponseEntity<Void> unlike(
-            @PathVariable Long communityId,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ){
-        communityLikeService.unlike(communityId, userDetails.getUserId());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/tave/PromptMate/dto/community/CommunityLikeToggleResponse.java
+++ b/src/main/java/com/tave/PromptMate/dto/community/CommunityLikeToggleResponse.java
@@ -1,0 +1,6 @@
+package com.tave.PromptMate.dto.community;
+
+public record CommunityLikeToggleResponse (
+    boolean isLiked,
+    long likeCount
+){}

--- a/src/main/java/com/tave/PromptMate/service/CommunityLikeService.java
+++ b/src/main/java/com/tave/PromptMate/service/CommunityLikeService.java
@@ -3,6 +3,7 @@ package com.tave.PromptMate.service;
 import com.tave.PromptMate.domain.Community;
 import com.tave.PromptMate.domain.CommunityLike;
 import com.tave.PromptMate.domain.User;
+import com.tave.PromptMate.dto.community.CommunityLikeToggleResponse;
 import com.tave.PromptMate.repository.CommunityLikeRepository;
 import com.tave.PromptMate.repository.CommunityRepository;
 import com.tave.PromptMate.repository.UserRepository;
@@ -19,18 +20,37 @@ public class CommunityLikeService {
     private final CommunityLikeRepository communityLikeRepository;
 
     @Transactional
-    public void like(Long communityId, Long userId){
+    public CommunityLikeToggleResponse toggleLike(Long communityId, Long userId) {
 
-        // 게시글 존재 확인
         Community community = communityRepository.findById(communityId)
-                .orElseThrow(()->new IllegalStateException("게시글이 존재하지 않습니다."));
+                .orElseThrow(() -> new IllegalStateException("게시글이 존재하지 않습니다."));
 
-        // 사용자 존재 확인
         User user = userRepository.findById(userId)
-                .orElseThrow(()-> new IllegalStateException("사용자가 존재하지 않습니다."));
+                .orElseThrow(() -> new IllegalStateException("사용자가 존재하지 않습니다."));
 
-        // 이미 좋아요 눌렀으면 그냥 종료
-        if (communityLikeRepository.existsByUserIdAndCommunityId(userId, communityId)){
+        boolean alreadyLiked =
+                communityLikeRepository.existsByUserIdAndCommunityId(userId, communityId);
+
+        if (alreadyLiked) {
+            communityLikeRepository.deleteByUserIdAndCommunityId(userId, communityId);
+        } else {
+            communityLikeRepository.save(CommunityLike.of(user, community));
+        }
+
+        long likeCount = communityLikeRepository.countByCommunityId(communityId);
+        return new CommunityLikeToggleResponse(!alreadyLiked, likeCount);
+    }
+
+    @Transactional
+    public void like(Long communityId, Long userId) {
+
+        Community community = communityRepository.findById(communityId)
+                .orElseThrow(() -> new IllegalStateException("게시글이 존재하지 않습니다."));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException("사용자가 존재하지 않습니다."));
+
+        if (communityLikeRepository.existsByUserIdAndCommunityId(userId, communityId)) {
             return;
         }
         communityLikeRepository.save(CommunityLike.of(user, community));
@@ -45,14 +65,13 @@ public class CommunityLikeService {
     }
 
     @Transactional(readOnly = true)
-    public long getLikeCount(Long communityId){
+    public long getLikeCount(Long communityId) {
         return communityLikeRepository.countByCommunityId(communityId);
     }
 
     @Transactional(readOnly = true)
-    public boolean isLiked(Long communityId, Long userId){
-        if(userId==null) return false;
+    public boolean isLiked(Long communityId, Long userId) {
+        if (userId == null) return false;
         return communityLikeRepository.existsByUserIdAndCommunityId(userId, communityId);
     }
 }
-


### PR DESCRIPTION
close #52

## 📝 작업 내용

커뮤니티 게시글 좋아요 API를 기존 like / unlike 분리 방식에서
단일 토글(toggle) 방식으로 변경했습니다.

- POST /communities/{communityId}/likes 요청 시
- 이미 좋아요 상태인 경우 → 좋아요 취소
- 좋아요가 없는 경우 → 좋아요 등록
- 기존 DELETE /likes 엔드포인트는 사용하지 않도록 정리

<img width="604" height="210" alt="스크린샷 2026-01-05 오전 4 25 47" src="https://github.com/user-attachments/assets/71c448d3-16d5-4f21-a56d-af6ad05e70b5" />

