### PR TITLE
feat : 커뮤니티 게시글 삭제를 물리 삭제로 변경

### DIFF
--- a/src/main/java/com/tave/PromptMate/repository/CommentRepository.java
+++ b/src/main/java/com/tave/PromptMate/repository/CommentRepository.java
@@ -10,5 +10,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findByParentIdOrderByCreatedAtAsc(Long parentId);
 
-    long countByCommunityId(long communityId);
+    long countByCommunityId(Long communityId);
+
+    void deleteByCommunityId(Long communityId);
 }

--- a/src/main/java/com/tave/PromptMate/repository/CommunityLikeRepository.java
+++ b/src/main/java/com/tave/PromptMate/repository/CommunityLikeRepository.java
@@ -10,4 +10,6 @@ public interface CommunityLikeRepository extends JpaRepository<CommunityLike, Lo
     long countByCommunityId(Long communityId);
 
     void deleteByUserIdAndCommunityId(Long userId, Long communityId);
+
+    void deleteByCommunityId(Long communityId);
 }

--- a/src/main/java/com/tave/PromptMate/service/CommunityLikeService.java
+++ b/src/main/java/com/tave/PromptMate/service/CommunityLikeService.java
@@ -74,4 +74,9 @@ public class CommunityLikeService {
         if (userId == null) return false;
         return communityLikeRepository.existsByUserIdAndCommunityId(userId, communityId);
     }
+
+    @Transactional
+    public void deleteAllByPostId(Long communityId){
+        communityLikeRepository.deleteByCommunityId(communityId);
+    }
 }

--- a/src/main/java/com/tave/PromptMate/service/CommunityService.java
+++ b/src/main/java/com/tave/PromptMate/service/CommunityService.java
@@ -79,10 +79,6 @@ public class CommunityService {
         Community post=communityRepository.findById(postId)
                 .orElseThrow(()->new NotFoundException("존재하지 않는 게시글입니다. id="+postId));
 
-        if(post.getVisibility()==Community.Visibility.REMOVED){
-            throw new NotFoundException("삭제된 게시글입니다.");
-        }
-
         //작성자 검증
         if(!post.getUser().getId().equals(userId)){
             throw new IllegalStateException("수정 권한이 없습니다.");
@@ -106,10 +102,13 @@ public class CommunityService {
             throw new IllegalStateException("삭제 권한이 없습니다. ");
         }
 
-        post.remove();
+        communityLikeService.deleteAllByPostId(postId);
 
-        // 라이브러리에서도 삭제
+        commentRepository.deleteByCommunityId(postId);
+
         libraryRepository.findByCommunity_Id(postId).ifPresent(libraryRepository::delete);
+
+        communityRepository.delete(post);
 
     }
     // 4) 게시글 목록 조회(최신순/조회순/좋아요순)
@@ -152,9 +151,6 @@ public class CommunityService {
         Community post = communityRepository.findById(postId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 게시글입니다. id=" + postId));
 
-        if (post.getVisibility() == Community.Visibility.REMOVED) {
-            throw new NotFoundException("삭제된 게시글입니다.");
-        }
 
         post.increaseViewCount();
 


### PR DESCRIPTION
close #45

## 📝 작업 내용
- 커뮤니티 게시글 삭제 정책을 soft delete에서 물리 삭제(hard delete)로 변경했습니다.
- 게시글 삭제 시 연관된 데이터(댓글, 좋아요, 라이브러리)도 함께 삭제되도록 처리했습니다.
- 삭제 이후 DB에서 게시글 row가 실제로 제거되는 것을 확인했습니다.

