### PR TITLE
feat: return rewriteResultId on rewrite preview

### DIFF
--- a/src/main/java/com/tave/PromptMate/controller/RewriteController.java
+++ b/src/main/java/com/tave/PromptMate/controller/RewriteController.java
@@ -53,8 +53,10 @@ public class RewriteController {
         AiRewriteResult result = rewriteRunner.run(req.prompt());
         System.out.println("RewriteRunner bean = " + rewriteRunner.getClass().getName());
 
+        Long rewriteResultId = rewriteResultService.createDraft(userId, req.prompt(), result);
 
         return ResponseEntity.ok(new RewritePreviewResponse(
+                rewriteResultId,
                 result.rewrittenContent(),
                 result.latencyMs(),
                 result.modelName(),

--- a/src/main/java/com/tave/PromptMate/domain/RewriteResult.java
+++ b/src/main/java/com/tave/PromptMate/domain/RewriteResult.java
@@ -12,8 +12,11 @@ public class RewriteResult extends BaseTimeEntity{
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "prompt_id")
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name="prompt_id", nullable = true)
     private Prompt prompt;
 
     @Column(nullable = false, length = 50)

--- a/src/main/java/com/tave/PromptMate/dto/rewrite/RewritePreviewResponse.java
+++ b/src/main/java/com/tave/PromptMate/dto/rewrite/RewritePreviewResponse.java
@@ -1,6 +1,7 @@
 package com.tave.PromptMate.dto.rewrite;
 
 public record RewritePreviewResponse(
+        Long rewriteResultId,
         String rewrittenPrompt,
         Long latencyMs,
         String modelName,

--- a/src/main/java/com/tave/PromptMate/service/RewriteResultService.java
+++ b/src/main/java/com/tave/PromptMate/service/RewriteResultService.java
@@ -1,8 +1,10 @@
 package com.tave.PromptMate.service;
 
 import com.tave.PromptMate.common.NotFoundException;
+import com.tave.PromptMate.common.RewriteRunner;
 import com.tave.PromptMate.domain.Prompt;
 import com.tave.PromptMate.domain.RewriteResult;
+import com.tave.PromptMate.dto.rewrite.AiRewriteResult;
 import com.tave.PromptMate.dto.rewrite.CreateRewriteRequest;
 import com.tave.PromptMate.dto.rewrite.RewriteMapper;
 import com.tave.PromptMate.dto.rewrite.RewriteResponse;
@@ -11,8 +13,6 @@ import com.tave.PromptMate.repository.RewriteResultRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.tave.PromptMate.common.RewriteRunner;
-
 
 import java.util.List;
 
@@ -24,6 +24,27 @@ public class RewriteResultService {
     private final RewriteResultRepository rewriteResultRepository;
     private final PromptRepository promptRepository;
     private final RewriteRunner rewriteRunner;
+
+
+    public Long createDraft(Long userId, String beforePrompt, AiRewriteResult ai) {
+
+        RewriteResult entity = RewriteResult.builder()
+                .userId(userId)
+                .prompt(null)
+                .modelName(ai.modelName())
+                .inputTokens(ai.inputTokens())
+                .outputTokens(ai.outputTokens())
+                .latencyMs(ai.latencyMs())
+                .content(ai.rewrittenContent())
+                .build();
+
+        rewriteResultRepository.save(entity);
+        return entity.getId();
+    }
+
+
+
+
 
     public RewriteResponse createAuto(Long promptId) {
 


### PR DESCRIPTION
## 작업 내용

- /api/rewrite 호출 시 AI 리라이팅 결과를 DB에 draft로 저장하고, 응답에 rewriteResultId를 포함하도록 변경했습니다.
- 다른 팀원이 해당 id를 이용해 후속 “저장하기” API를 호출할 수 있도록 식별자 흐름을 마련했습니다.

## 변경 사항 
#### POST /api/rewrite

기존: 리라이팅 결과 텍스트만 반환

변경: 
- 리라이팅 결과를 draft로 저장 후 rewriteResultId 포함 반환
- RewritePreviewResponse DTO에 rewriteResultId 필드 추가
- RewriteResultService에 draft 저장 로직(createDraft) 추가/정리

## API 응답 예시
<img width="1479" height="382" alt="image" src="https://github.com/user-attachments/assets/09b44a0b-a20b-4e02-99f1-95a78da45e22" />
