### PR TITLE
feat: 최근 본 프롬프트 기능 추가

### DIFF
--- a/src/main/java/com/tave/PromptMate/controller/CommunityController.java
+++ b/src/main/java/com/tave/PromptMate/controller/CommunityController.java
@@ -3,10 +3,8 @@ package com.tave.PromptMate.controller;
 import com.tave.PromptMate.auth.dto.request.CustomUserDetails;
 import com.tave.PromptMate.common.S3Uploader;
 import com.tave.PromptMate.domain.Community;
-import com.tave.PromptMate.dto.community.CommunityPostMapper;
-import com.tave.PromptMate.dto.community.CommunityPostResponse;
-import com.tave.PromptMate.dto.community.CreateCommunityPostRequest;
-import com.tave.PromptMate.dto.community.UpdateCommunityPostRequest;
+import com.tave.PromptMate.dto.community.*;
+import com.tave.PromptMate.service.CommunityRecentService;
 import com.tave.PromptMate.service.CommunityService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +25,7 @@ public class CommunityController {
 
     private final CommunityService communityService;
     private final S3Uploader s3Uploader;
+    private final CommunityRecentService communityRecentService;
 
     // 커뮤니티 글 작성
     @PostMapping(value="/posts", consumes= MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -100,5 +99,15 @@ public class CommunityController {
     ) {
         Long userId = (principal == null) ? null : principal.getUserId();
         return ResponseEntity.ok(communityService.getPost(postId, userId));
+    }
+
+    // 최근 본 프롬프트
+    @GetMapping("/recent")
+    public ResponseEntity<List<CommunityRecentRow>> getRecentCommunities(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @RequestParam(defaultValue = "20") int limit
+    ){
+        Long userId= principal.getUserId();
+        return ResponseEntity.ok(communityRecentService.getRecent(userId,limit));
     }
 }

--- a/src/main/java/com/tave/PromptMate/domain/CommunityRecent.java
+++ b/src/main/java/com/tave/PromptMate/domain/CommunityRecent.java
@@ -1,0 +1,55 @@
+package com.tave.PromptMate.domain;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+
+@Entity
+@Table(
+        name="community_recent",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_user_community",
+                columnNames = {"user_id", "community_id"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommunityRecent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 최근 본 유저
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 최근 본 커뮤니티 게시글
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "community_id", nullable = false)
+    private Community community;
+
+    // 마지막 조회 시간
+    @Column(name = "last_viewed_at", nullable = false)
+    private LocalDateTime lastViewedAt;
+
+    public static CommunityRecent create(User user, Community community){
+        CommunityRecent recent=new CommunityRecent();
+        recent.user=user;
+        recent.community=community;
+        recent.lastViewedAt=LocalDateTime.now();
+        return recent;
+    }
+
+    // 다시 조회했을 때 시간 갱신
+    public void touch(){
+        this.lastViewedAt=LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/tave/PromptMate/dto/community/CommunityRecentRow.java
+++ b/src/main/java/com/tave/PromptMate/dto/community/CommunityRecentRow.java
@@ -1,0 +1,11 @@
+package com.tave.PromptMate.dto.community;
+
+import java.time.LocalDateTime;
+
+public record CommunityRecentRow(
+        Long postId,
+        String title,
+        String platform,
+        String category,
+        LocalDateTime lastViewedAt
+){}

--- a/src/main/java/com/tave/PromptMate/repository/CommunityRecentRepository.java
+++ b/src/main/java/com/tave/PromptMate/repository/CommunityRecentRepository.java
@@ -1,0 +1,34 @@
+package com.tave.PromptMate.repository;
+
+import com.tave.PromptMate.domain.CommunityRecent;
+import com.tave.PromptMate.dto.community.CommunityRecentRow;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CommunityRecentRepository extends JpaRepository<CommunityRecent,Long> {
+
+    // 이미 기록이 있는지 확인
+    Optional<CommunityRecent> findByUser_IdAndCommunity_Id(Long userId, Long communityId);
+
+    @Query("""
+        select new com.tave.PromptMate.dto.community.CommunityRecentRow(
+            c.id,
+            c.title,
+            c.platform,
+            c.category,
+            r.lastViewedAt
+        )
+        from CommunityRecent r
+        join r.community c
+        where r.user.id = :userId
+          and c.visibility <> com.tave.PromptMate.domain.Community.Visibility.REMOVED
+        order by r.lastViewedAt desc
+    """)
+    List<CommunityRecentRow> findRecentByUserId(@Param("userId") Long userId, Pageable pageable);
+}
+

--- a/src/main/java/com/tave/PromptMate/service/CommunityRecentService.java
+++ b/src/main/java/com/tave/PromptMate/service/CommunityRecentService.java
@@ -1,0 +1,52 @@
+package com.tave.PromptMate.service;
+
+
+import com.tave.PromptMate.common.NotFoundException;
+import com.tave.PromptMate.domain.Community;
+import com.tave.PromptMate.domain.CommunityRecent;
+import com.tave.PromptMate.domain.User;
+import com.tave.PromptMate.dto.community.CommunityRecentRow;
+import com.tave.PromptMate.repository.CommunityRecentRepository;
+import com.tave.PromptMate.repository.CommunityRepository;
+import com.tave.PromptMate.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommunityRecentService {
+
+    private final CommunityRecentRepository communityRecentRepository;
+    private final UserRepository userRepository;
+    private final CommunityRepository communityRepository;
+
+    // 최근 본 목록 조회
+    @Transactional
+    public List<CommunityRecentRow> getRecent(Long userId, int limit){
+        return communityRecentRepository.findRecentByUserId(
+                userId,
+                PageRequest.of(0,limit)
+        );
+    }
+
+    // 최근 본 프롬프트 저장/갱신
+    @Transactional
+    public void upsert(Long userId, Long communityId){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자입니다. id=" + userId));
+
+        Community community = communityRepository.findById(communityId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 게시글입니다. id=" + communityId));
+
+        communityRecentRepository.findByUser_IdAndCommunity_Id(userId, communityId)
+                .ifPresentOrElse(
+                        CommunityRecent::touch,
+                        () -> communityRecentRepository.save(CommunityRecent.create(user, community)) // 없으면 생성
+                );
+    }
+}

--- a/src/main/java/com/tave/PromptMate/service/CommunityService.java
+++ b/src/main/java/com/tave/PromptMate/service/CommunityService.java
@@ -20,6 +20,7 @@ public class CommunityService {
     private final LibraryRepository libraryRepository;
     private final CommentRepository commentRepository;
     private final CommunityLikeService communityLikeService;
+    private final CommunityRecentService communityRecentService;
 
     public CommunityPostResponse createPost(CreateCommunityPostRequest req, Long userId) {
 
@@ -145,9 +146,13 @@ public class CommunityService {
 
         post.increaseViewCount();
 
+        if(userId!=null){
+            communityRecentService.upsert(userId,postId);
+        }
+
         long likeCount = communityLikeService.getLikeCount(postId);
         long commentCount=commentRepository.countByCommunityId(postId);
-        boolean isLiked = communityLikeService.isLiked(postId, userId);
+        boolean isLiked = (userId != null) && communityLikeService.isLiked(postId, userId);
 
         return CommunityPostMapper.toResponse(post, likeCount, commentCount, isLiked);
     }


### PR DESCRIPTION
close #82 

## 📝 작업 내용

- 커뮤니티 게시글 단건 조회 시, 사용자가 조회한 게시글을 최근 본 게시글로 저장하도록 기능을 추가했다.
- 사용자 기준으로 최근 본 커뮤니티 게시글 목록 조회 API를 구현했다.
- 동일 게시글을 다시 조회할 경우, 새로운 레코드를 생성하지 않고 `lastViewedAt`을 갱신하도록 처리했다.

<img width="589" height="476" alt="스크린샷 2026-01-13 오후 10 36 44" src="https://github.com/user-attachments/assets/c71efd23-c79b-4c72-ae76-0dad0eab95ac" />

