### PR TITLE
rewriteResultId 중심 리라이팅 플로우 구축 + 레거시 API 숨김

### DIFF
--- a/src/main/java/com/tave/PromptMate/controller/EvaluationController.java
+++ b/src/main/java/com/tave/PromptMate/controller/EvaluationController.java
@@ -1,17 +1,19 @@
 package com.tave.PromptMate.controller;
 
+import com.tave.PromptMate.dto.evaluation.AutoEvaluationRequest;
 import com.tave.PromptMate.dto.evaluation.EvaluationResponse;
 import com.tave.PromptMate.dto.evaluation.EvaluationSummaryResponse;
 import com.tave.PromptMate.service.EvaluationService;
+import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import com.tave.PromptMate.dto.evaluation.AutoEvaluationRequest;
 
 import java.net.URI;
 
+@Hidden
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/evaluations")

--- a/src/main/java/com/tave/PromptMate/controller/PromptController.java
+++ b/src/main/java/com/tave/PromptMate/controller/PromptController.java
@@ -5,6 +5,7 @@ import com.tave.PromptMate.dto.prompt.PromptAutoResponse;
 import com.tave.PromptMate.dto.prompt.PromptResponse;
 import com.tave.PromptMate.dto.prompt.UpdatePromptRequest;
 import com.tave.PromptMate.service.PromptService;
+import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
+@Hidden
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/prompts")

--- a/src/main/java/com/tave/PromptMate/controller/RewriteController.java
+++ b/src/main/java/com/tave/PromptMate/controller/RewriteController.java
@@ -4,16 +4,18 @@ import com.tave.PromptMate.auth.dto.request.CustomUserDetails;
 import com.tave.PromptMate.common.RewriteRunner;
 import com.tave.PromptMate.dto.rewrite.*;
 import com.tave.PromptMate.service.RewriteResultService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.net.URI;
 import java.util.List;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -65,25 +67,36 @@ public class RewriteController {
 
     }
 
-    // 리라이티 결과 생성(저장)하기
-    @PostMapping("rewrite-results")
-    public ResponseEntity<RewriteResponse> create(
+    //  내 리라이팅 히스토리(페이징)
+    @GetMapping("/rewrite-results/my")
+    public ResponseEntity<Page<RewriteHistoryItemResponse>> getMyHistory(
             @AuthenticationPrincipal CustomUserDetails principal,
-            @RequestBody @Valid CreateRewriteRequest req){
-
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
         Long userId = requireUserId(principal);
-
-        RewriteResponse res = rewriteResultService.create(req);
-        return ResponseEntity.created(URI.create("/api/rewrite-results/" + res.id())).body(res);
+        return ResponseEntity.ok(rewriteResultService.getMyHistory(userId, page, size));
     }
 
+    //  내 최신 리라이팅 1건
+    @GetMapping("/rewrite-results/my/latest")
+    public ResponseEntity<RewriteHistoryItemResponse> getMyLatest(
+            @AuthenticationPrincipal CustomUserDetails principal
+    ) {
+        Long userId = requireUserId(principal);
+        return ResponseEntity.ok(rewriteResultService.getMyLatest(userId));
+    }
+
+
     // 프롬프트별 리라이팅 결과 전체 목록 조회
+    @Operation(hidden = true, deprecated = true)
     @GetMapping("/prompts/{promptId}/rewrites")
     public ResponseEntity<List<RewriteResponse>> getByPrompt(@PathVariable Long promptId){
         return ResponseEntity.ok(rewriteResultService.getListByPrompt(promptId));
     }
 
     // 프롬프트별 최신 1건 조회
+    @Operation(hidden = true, deprecated = true)
     @GetMapping("/prompts/{promptId}/rewrites/latest")
     public ResponseEntity<RewriteResponse> getLatest(
             @AuthenticationPrincipal CustomUserDetails principal,
@@ -96,6 +109,7 @@ public class RewriteController {
     }
 
     // 리라이팅 결과 단건 조회
+    @Operation(hidden = true, deprecated = true)
     @GetMapping("/rewrite-results/{id}")
     public ResponseEntity<RewriteResponse> getOne(
             @AuthenticationPrincipal CustomUserDetails principal,
@@ -107,6 +121,7 @@ public class RewriteController {
     }
 
     // 리라이팅 삭제하기
+    @Operation(hidden = true, deprecated = true)
     @DeleteMapping("/rewrite-results/{id}")
     public ResponseEntity<Void> delete(
             @AuthenticationPrincipal CustomUserDetails principal,

--- a/src/main/java/com/tave/PromptMate/dto/rewrite/RewriteHistoryItemResponse.java
+++ b/src/main/java/com/tave/PromptMate/dto/rewrite/RewriteHistoryItemResponse.java
@@ -1,0 +1,14 @@
+package com.tave.PromptMate.dto.rewrite;
+
+import java.time.LocalDateTime;
+
+public record RewriteHistoryItemResponse(
+        Long rewriteResultId,
+        Long promptId,
+        String beforePrompt,      // 원문
+        String rewrittenPrompt,   // 결과
+        Long latencyMs,
+        String modelName,
+        String version,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/tave/PromptMate/repository/RewriteResultRepository.java
+++ b/src/main/java/com/tave/PromptMate/repository/RewriteResultRepository.java
@@ -1,6 +1,8 @@
 package com.tave.PromptMate.repository;
 
 import com.tave.PromptMate.domain.RewriteResult;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -13,4 +15,9 @@ public interface RewriteResultRepository extends JpaRepository<RewriteResult, Lo
 
     // 프롬프트별 전체 리라이팅 (최신순)
     List<RewriteResult> findByPromptIdOrderByCreatedAtDesc(Long promptId);
+
+    Page<RewriteResult> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    Optional<RewriteResult> findTopByUserIdOrderByCreatedAtDesc(Long userId);
+
 }

--- a/src/main/java/com/tave/PromptMate/service/RewriteResultService.java
+++ b/src/main/java/com/tave/PromptMate/service/RewriteResultService.java
@@ -4,13 +4,15 @@ import com.tave.PromptMate.common.NotFoundException;
 import com.tave.PromptMate.common.RewriteRunner;
 import com.tave.PromptMate.domain.Prompt;
 import com.tave.PromptMate.domain.RewriteResult;
-import com.tave.PromptMate.dto.rewrite.AiRewriteResult;
-import com.tave.PromptMate.dto.rewrite.CreateRewriteRequest;
-import com.tave.PromptMate.dto.rewrite.RewriteMapper;
-import com.tave.PromptMate.dto.rewrite.RewriteResponse;
+import com.tave.PromptMate.domain.User;
+import com.tave.PromptMate.dto.rewrite.*;
 import com.tave.PromptMate.repository.PromptRepository;
 import com.tave.PromptMate.repository.RewriteResultRepository;
+import com.tave.PromptMate.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,13 +26,28 @@ public class RewriteResultService {
     private final RewriteResultRepository rewriteResultRepository;
     private final PromptRepository promptRepository;
     private final RewriteRunner rewriteRunner;
+    private final UserRepository userRepository;
 
 
     public Long createDraft(Long userId, String beforePrompt, AiRewriteResult ai) {
 
+        User user = userRepository.findById(userId)
+                .orElseThrow(()->new NotFoundException("user not found: " + userId));
+
+        Prompt prompt = Prompt.builder()
+                .user(user)
+                .title("Draft Prompt")
+                .content(beforePrompt)
+                .deleted(true)
+                .isPrivate(true)
+                .category(null)
+                .build();
+
+        promptRepository.save(prompt);
+
         RewriteResult entity = RewriteResult.builder()
                 .userId(userId)
-                .prompt(null)
+                .prompt(prompt)
                 .modelName(ai.modelName())
                 .inputTokens(ai.inputTokens())
                 .outputTokens(ai.outputTokens())
@@ -41,6 +58,39 @@ public class RewriteResultService {
         rewriteResultRepository.save(entity);
         return entity.getId();
     }
+
+    public Page<RewriteHistoryItemResponse> getMyHistory(Long userId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+
+        return rewriteResultRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable)
+                .map(rr -> new RewriteHistoryItemResponse(
+                        rr.getId(),
+                        rr.getPrompt() != null ? rr.getPrompt().getId() : null,
+                        rr.getPrompt() != null ? rr.getPrompt().getContent() : null,
+                        rr.getContent(),
+                        rr.getLatencyMs(),
+                        rr.getModelName(),
+                        "v1",
+                        rr.getCreatedAt()
+                ));
+    }
+
+    public RewriteHistoryItemResponse getMyLatest(Long userId) {
+        RewriteResult rr = rewriteResultRepository.findTopByUserIdOrderByCreatedAtDesc(userId)
+                .orElseThrow(() -> new NotFoundException("내 리라이팅 기록이 없습니다. userId=" + userId));
+
+        return new RewriteHistoryItemResponse(
+                rr.getId(),
+                rr.getPrompt() != null ? rr.getPrompt().getId() : null,
+                rr.getPrompt() != null ? rr.getPrompt().getContent() : null,
+                rr.getContent(),
+                rr.getLatencyMs(),
+                rr.getModelName(),
+                "v1",
+                rr.getCreatedAt()
+        );
+    }
+
 
 
 


### PR DESCRIPTION
## 작업 내용

1) /api/rewrite를 중심으로 리라이팅 플로우 고도화
- POST /api/rewrite
- AI 리라이팅 서버 호출
- Draft 리라이팅 결과 생성 및 DB 저장

2) 내 리라이팅 히스토리 조회 API 신규 추가
- GET /api/rewrite-results/my (페이징)
- GET /api/rewrite-results/my/latest (최신 1건)
- 프론트에서 promptId를 몰라도 리라이팅 결과 흐름을 완결할 수 있도록 rewriteResultId 중심으로 조회 구조를 제공했습니다.

3) 레거시(프롬프트 기반) API Swagger 노출 정리

- 프론트에서 사용하지 않는 레거시 API는 혼선을 줄이기 위해 Swagger에서 숨김(hidden) + deprecated 처리했습니다.
- Prompt 기반 리라이팅 조회(/api/prompts/{promptId}/rewrites*) 숨김
- 저장/생성 혼선을 주는 POST /api/rewrite-results 숨김(삭제 후보로 관리)

PromptController의 /api/prompts/**는 외부 노출 대상이 아니므로 Swagger에서 숨김 처리
(단, Prompt 도메인/테이블은 리라이팅 결과 추적(prompt_id 연결) 용도로 내부적으로 유지)