### PR TITLE
feat: 좋아요순 인기 프롬프트 기능 구현

### DIFF
--- a/src/main/java/com/tave/PromptMate/controller/CommunityController.java
+++ b/src/main/java/com/tave/PromptMate/controller/CommunityController.java
@@ -115,4 +115,14 @@ public class CommunityController {
         Long userId= principal.getUserId();
         return ResponseEntity.ok(communityRecentService.getRecent(userId,limit));
     }
+
+    // 오늘의 인기 프롬프트
+    @GetMapping("/popular")
+    public ResponseEntity<List<CommunityPostResponse>> popular(
+            @AuthenticationPrincipal CustomUserDetails principal
+    ) {
+        Long userId = (principal == null) ? null : principal.getUserId();
+        return ResponseEntity.ok(communityService.getPopularTop5(userId));
+    }
+
 }

--- a/src/main/java/com/tave/PromptMate/repository/CommunityRepository.java
+++ b/src/main/java/com/tave/PromptMate/repository/CommunityRepository.java
@@ -5,6 +5,7 @@ import com.tave.PromptMate.domain.Community.Visibility;
 import com.tave.PromptMate.domain.Platform;
 import com.tave.PromptMate.domain.PromptCategory;
 import com.tave.PromptMate.dto.community.CommunityPostRow;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -142,6 +143,42 @@ public interface CommunityRepository extends JpaRepository<Community, Long> {
             @Param("platform") Platform platform,
             @Param("category") PromptCategory category,
             @Param("userId") Long userId
+    );
+
+    // 좋아요순 인기 프롬프트
+    @Query("""
+select new com.tave.PromptMate.dto.community.CommunityPostRow(
+    c.id,
+    rr.id,
+    u.id,
+    u.nickname,
+    c.title,
+    c.promptContent,
+    c.visibility,
+    c.description,
+    c.createdAt,
+    c.viewCount,
+    (select count(cl) from CommunityLike cl where cl.community.id = c.id),
+    (select count(cm) from Comment cm where cm.community.id = c.id),
+    (case when :userId is null then false
+          when (select count(cl2) from CommunityLike cl2
+                where cl2.community.id = c.id and cl2.user.id = :userId) > 0
+          then true else false end),
+    c.platform,
+    c.category,
+    c.imageUrl
+)
+from Community c
+join c.rewriteResult rr
+join c.user u
+where c.visibility <> com.tave.PromptMate.domain.Community.Visibility.REMOVED
+order by
+    (select count(cl) from CommunityLike cl where cl.community.id = c.id) desc,
+    c.createdAt desc
+""")
+    List<CommunityPostRow> findPopularTop(
+            @Param("userId") Long userId,
+            Pageable pageable
     );
 
 }

--- a/src/main/java/com/tave/PromptMate/service/CommunityService.java
+++ b/src/main/java/com/tave/PromptMate/service/CommunityService.java
@@ -5,6 +5,7 @@ import com.tave.PromptMate.domain.*;
 import com.tave.PromptMate.dto.community.*;
 import com.tave.PromptMate.repository.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -173,4 +174,31 @@ public class CommunityService {
         return CommunityPostMapper.toResponse(post, likeCount, commentCount, isLiked);
     }
 
+    // 홈 - 오늘의 인기 프롬프트
+    @Transactional(readOnly = true)
+    public List<CommunityPostResponse> getPopularTop5(Long userId) {
+        List<CommunityPostRow> rows =
+                communityRepository.findPopularTop(userId, PageRequest.of(0, 5));
+
+        return rows.stream()
+                .map(r -> new CommunityPostResponse(
+                        r.id(),
+                        r.rewriteResultId(),
+                        r.userId(),
+                        r.nickname(),
+                        r.title(),
+                        r.promptContent(),
+                        r.description(),
+                        r.visibility(),
+                        r.createdAt(),
+                        r.viewCount(),
+                        r.likeCount(),
+                        r.commentCount(),
+                        r.isLiked(),
+                        r.platform(),
+                        r.category(),
+                        r.imageUrl()
+                ))
+                .toList();
+    }
 }


### PR DESCRIPTION
close #83

## 📝 작업 내용

- 커뮤니티 게시글 목록 조회에서 좋아요 수 기준 정렬 기능을 추가했습니다.
- 좋아요 수 내림차순으로 정렬되며, 동점일 경우 최신 게시글이 우선 노출되도록 처리했습니다.

<img width="733" height="613" alt="스크린샷 2026-01-15 오후 12 35 32" src="https://github.com/user-attachments/assets/3963f757-f928-4738-9249-15682b6195a1" />


