### PR TITLE
chore: hide unused rewrite my endpoints from swagger

### DIFF
--- a/src/main/java/com/tave/PromptMate/controller/RewriteController.java
+++ b/src/main/java/com/tave/PromptMate/controller/RewriteController.java
@@ -6,7 +6,6 @@ import com.tave.PromptMate.dto.rewrite.*;
 import com.tave.PromptMate.service.RewriteResultService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -28,6 +27,7 @@ public class RewriteController {
     private final RewriteResultService rewriteResultService;
     private final RewriteRunner rewriteRunner;
 
+    @Operation(hidden = true, deprecated = true)
     @GetMapping("/me")
     public ResponseEntity<String> getAuthenticatedUserInfo(
             @AuthenticationPrincipal CustomUserDetails principal) {
@@ -72,6 +72,7 @@ public class RewriteController {
     }
 
     //  내 리라이팅 히스토리(페이징)
+    @Operation(hidden = true, deprecated = true)
     @GetMapping("/rewrite-results/my")
     public ResponseEntity<Page<RewriteHistoryItemResponse>> getMyHistory(
             @AuthenticationPrincipal CustomUserDetails principal,
@@ -83,6 +84,7 @@ public class RewriteController {
     }
 
     //  내 최신 리라이팅 1건
+    @Operation(hidden = true, deprecated = true)
     @GetMapping("/rewrite-results/my/latest")
     public ResponseEntity<RewriteHistoryItemResponse> getMyLatest(
             @AuthenticationPrincipal CustomUserDetails principal


### PR DESCRIPTION
## 변경 사항
- GET /rewrite-results/my, GET /rewrite-results/my/latest 엔드포인트를 Swagger에서 숨김 처리
- API 명세서에서 해당 항목 제거

## 변경 이유
- 현재 서비스 플로우에서 사용되지 않는 엔드포인트로, 명세/Swagger 노출 시 혼란 및 불필요 유지보수 발생

## 검증
- Swagger UI에서 두 엔드포인트 노출되지 않음 확인
- 기존 리라이팅 기능 정상 동작 확인